### PR TITLE
Feature/royalty payments

### DIFF
--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -266,7 +266,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
                 auctions[auctionId].bidder,
                 tokenOwnerProfit,
                 commissionAddress,
-                commissionAmount            
+                commissionAmount,            
                 currency
             );
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -252,9 +252,9 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         if (auctions[auctionId].commissionAddress != address(0) && auctions[auctionId].commissionPercentage > 0){
             uint256 commissionAmount = _generateCommission(auctionId);
-            uint256 tokenOwnerRemainingAmount = tokenOwnerProfit.sub(commissionAmount);
+            uint256 amountRemaining = tokenOwnerProfit.sub(commissionAmount);
 
-            _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(auctions[auctionId].tokenOwner, amountRemaining, auctions[auctionId].auctionCurrency);
 
             _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -120,7 +120,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionReservePriceUpdated(auctionId, auctions[auctionId].tokenId, auctions[auctionId].tokenContract, reservePrice);
     }
 
-    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external auctionExists(auctionId) {
+    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external override auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 
@@ -129,7 +129,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionCommissionAddressUpdated(auctionId, commissionAddress);
     }
 
-    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external auctionExists(auctionId) {
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external override auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -256,7 +256,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
             _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
 
-            _handleOutGoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
 
             emit AuctionWithCommissionEnded(
                 auctionId,

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -252,7 +252,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         if (auctions[auctionId].commissionAddress != address(0) && auctions[auctionId].commissionPercentage > 0){
             uint256 commissionAmount = _generateCommission(auctionId);
-            tokenOwnerProfit = tokenOwnerProfit.sub(commissionAmount);
+            uint256 tokenOwnerRemainingAmount = tokenOwnerProfit.sub(commissionAmount);
 
             _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
 
@@ -265,7 +265,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
                 auctions[auctionId].tokenOwner,            
                 auctions[auctionId].bidder,
                 tokenOwnerProfit,
-                commissionAddress,
+                auctions[auctionId].commissionAddress,
                 commissionAmount,            
                 currency
             );

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -337,7 +337,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateCommission(uint256 auctionId) internal return (uint256){
+    function _generateCommission(uint256 auctionId) internal {
         return auctions[auctionId].amount.div(100).mul(auctions[auctionId].commissionPercentage);
     }
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -129,7 +129,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionCommissionAddressUpdated(auctionId, commissionAddress);
     }
 
-    function updateCommissionPercentage(uint256 auctionId, uint8 commissionPercentage) external auctionExists(auctionId) {
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -97,7 +97,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             reservePrice: reservePrice,            
             tokenOwner: tokenOwner,
             bidder: address(0),            
-            auctionCurrency: auctionCurrency
+            auctionCurrency: auctionCurrency,
             commissionAddress: commissionAddress,
             commissionPercentage: comissionPercentage
         });

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -106,7 +106,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         _auctionIdTracker.increment();
 
-        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency);
+        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency, commissionAddress, commissionPercentage);
  
         return auctionId;
     }

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -99,7 +99,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             bidder: address(0),            
             auctionCurrency: auctionCurrency,
             commissionAddress: commissionAddress,
-            commissionPercentage: comissionPercentage
+            commissionPercentage: commissionPercentage
         });
 
         IERC721(tokenContract).transferFrom(tokenOwner, address(this), tokenId);

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -337,7 +337,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateCommission(uint256 auctionId) internal {
+    function _generateCommission(uint256 auctionId) internal returns (uint256) {
         return auctions[auctionId].amount.div(100).mul(auctions[auctionId].commissionPercentage);
     }
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -32,9 +32,6 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
     // The minimum percentage difference between the last bid amount and the current bid.
     uint8 public minBidIncrementPercentage;
 
-    // The address of the zora protocol to use via this contract
-    address public zora;
-
     // / The address of the WETH contract, so that any ETH transferred can be handled as an ERC-20
     address public wethAddress;
 
@@ -56,12 +53,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
     /*
      * Constructor
      */
-    constructor(address _zora, address _weth) public {
-        require(
-            IERC165(_zora).supportsInterface(interfaceId),
-            "Doesn't support NFT interface"
-        );
-        zora = _zora;
+    constructor(address _weth) public {
         wethAddress = _weth;
         timeBuffer = 15 * 60; // extend 15 minutes after every bid made in last 15 minutes
         minBidIncrementPercentage = 5; // 5%

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -98,7 +98,7 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
-    event AuctionEndedWithCommission(
+    event AuctionWithCommissionEnded(
         uint256 indexed auctionId,
         uint256 indexed tokenId,
         address indexed tokenContract,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -130,9 +130,9 @@ interface IAuctionHouse {
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 
-    function updateCommissionAddress(address commissionAddress) external;
+    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external;
 
-    function updateCommissionPercentage(address commissionAddress) external;
+    function updateCommissionPercentage(uint256 auctionId, address commissionAddress) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -98,6 +98,18 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
+    event AuctionEndedWithCommission(
+        uint256 indexed auctionId,
+        uint256 indexed tokenId,
+        address indexed tokenContract,
+        address tokenOwner,        
+        address winner,
+        uint256 amount,
+        address commissionAddress,
+        uint256 commissionAmount,        
+        address auctionCurrency
+    );
+
     event AuctionCanceled(
         uint256 indexed auctionId,
         uint256 indexed tokenId,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -62,12 +62,12 @@ interface IAuctionHouse {
     );
 
     event AuctionCommissionAddressUpdated(
-        uint256 indexed auctionId
+        uint256 indexed auctionId,
         address indexed commissionAddress
     )
 
     event AuctionCommissionAddressUpdated(
-        uint256 indexed auctionId
+        uint256 indexed auctionId,
         address indexed commissionAddress
     )
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -27,6 +27,13 @@ interface IAuctionHouse {
         // The address of the ERC-20 currency to run the auction with.
         // If set to 0x0, the auction will be run in ETH
         address auctionCurrency;
+        // The address of recipient of the sale commission
+        address commissionAddress;
+        //The address of the recipient of the sale commission
+        //If set to 0x0, no commission will generated
+        uint256 commissionPercentage;
+        // The percentage of the sale the commission address receives
+        //If percentage is set to 0, no commission will be generated
     }
 
     event AuctionCreated(
@@ -36,7 +43,9 @@ interface IAuctionHouse {
         uint256 duration,
         uint256 reservePrice,
         address tokenOwner,        
-        address auctionCurrency
+        address auctionCurrency,
+        address commissionAddress,
+        uint8 commissionPercentage
     );
 
     event AuctionApprovalUpdated(
@@ -51,6 +60,16 @@ interface IAuctionHouse {
         address indexed tokenContract,
         uint256 reservePrice
     );
+
+    event AuctionCommissionAddressUpdated(
+        uint256 indexed auctionId
+        address indexed commissionAddress
+    )
+
+    event AuctionCommissionAddressUpdated(
+        uint256 indexed auctionId
+        address indexed commissionAddress
+    )
 
     event AuctionBid(
         uint256 indexed auctionId,
@@ -91,11 +110,17 @@ interface IAuctionHouse {
         address tokenContract,
         uint256 duration,
         uint256 reservePrice,        
-        address auctionCurrency
+        address auctionCurrency,
+        address commissionAddress,
+        uint8 comissionPercentage
     ) external returns (uint256);
 
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
+
+    function updateCommissionAddress(address commissionAddress) external;
+
+    function updateCommissionPercentage(address commissionAddress) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -64,12 +64,12 @@ interface IAuctionHouse {
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
         address indexed commissionAddress
-    )
+    );
 
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
         address indexed commissionAddress
-    )
+    );
 
     event AuctionBid(
         uint256 indexed auctionId,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -132,7 +132,7 @@ interface IAuctionHouse {
 
     function updateCommissionAddress(uint256 auctionId, address commissionAddress) external;
 
-    function updateCommissionPercentage(uint256 auctionId, address commissionAddress) external;
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -63,12 +63,12 @@ interface IAuctionHouse {
 
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
-        address indexed commissionAddress
+        address indexed newCommissionAddress
     );
 
-    event AuctionCommissionAddressUpdated(
+    event AuctionCommissionPercentageUpdated(
         uint256 indexed auctionId,
-        address indexed commissionAddress
+        uint256 indexed newCommissionPercentage
     );
 
     event AuctionBid(


### PR DESCRIPTION
Optional commission functionality has been added! 

The auction struct now has two additional properties: commissionAddress and commissionPercentage. When endAuction is now called, if commissionAddress and commissionPercentage exist for the given auction object, the contract will calculate the commission amount and send that to the commission address. The amount remaining will be sent to the token owner. If commissionAddress and commissionPercentage do not exist, the contract will send the full amount to the token owner as it did previously.

There are also two setter functions for these variables in case we want to change either value after the auction is created which will need to be limited by access controls eventually.