### PR TITLE
Feature/royalty-payments

### DIFF
--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -266,7 +266,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
                 auctions[auctionId].bidder,
                 tokenOwnerProfit,
                 commissionAddress,
-                commissionAmount            
+                commissionAmount,            
                 currency
             );
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -252,9 +252,9 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         if (auctions[auctionId].commissionAddress != address(0) && auctions[auctionId].commissionPercentage > 0){
             uint256 commissionAmount = _generateCommission(auctionId);
-            uint256 tokenOwnerRemainingAmount = tokenOwnerProfit.sub(commissionAmount);
+            uint256 amountRemaining = tokenOwnerProfit.sub(commissionAmount);
 
-            _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(auctions[auctionId].tokenOwner, amountRemaining, auctions[auctionId].auctionCurrency);
 
             _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -120,7 +120,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionReservePriceUpdated(auctionId, auctions[auctionId].tokenId, auctions[auctionId].tokenContract, reservePrice);
     }
 
-    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external auctionExists(auctionId) {
+    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external override auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 
@@ -129,7 +129,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionCommissionAddressUpdated(auctionId, commissionAddress);
     }
 
-    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external auctionExists(auctionId) {
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external override auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -256,7 +256,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
             _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
 
-            _handleOutGoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
 
             emit AuctionWithCommissionEnded(
                 auctionId,

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -252,7 +252,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         if (auctions[auctionId].commissionAddress != address(0) && auctions[auctionId].commissionPercentage > 0){
             uint256 commissionAmount = _generateCommission(auctionId);
-            tokenOwnerProfit = tokenOwnerProfit.sub(commissionAmount);
+            uint256 tokenOwnerRemainingAmount = tokenOwnerProfit.sub(commissionAmount);
 
             _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
 
@@ -265,7 +265,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
                 auctions[auctionId].tokenOwner,            
                 auctions[auctionId].bidder,
                 tokenOwnerProfit,
-                commissionAddress,
+                auctions[auctionId].commissionAddress,
                 commissionAmount,            
                 currency
             );

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -337,7 +337,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateCommission(uint256 auctionId) internal return (uint256){
+    function _generateCommission(uint256 auctionId) internal {
         return auctions[auctionId].amount.div(100).mul(auctions[auctionId].commissionPercentage);
     }
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -129,7 +129,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionCommissionAddressUpdated(auctionId, commissionAddress);
     }
 
-    function updateCommissionPercentage(uint256 auctionId, uint8 commissionPercentage) external auctionExists(auctionId) {
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -97,7 +97,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             reservePrice: reservePrice,            
             tokenOwner: tokenOwner,
             bidder: address(0),            
-            auctionCurrency: auctionCurrency
+            auctionCurrency: auctionCurrency,
             commissionAddress: commissionAddress,
             commissionPercentage: comissionPercentage
         });

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -106,7 +106,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         _auctionIdTracker.increment();
 
-        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency);
+        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency, commissionAddress, commissionPercentage);
  
         return auctionId;
     }

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -99,7 +99,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             bidder: address(0),            
             auctionCurrency: auctionCurrency,
             commissionAddress: commissionAddress,
-            commissionPercentage: comissionPercentage
+            commissionPercentage: commissionPercentage
         });
 
         IERC721(tokenContract).transferFrom(tokenOwner, address(this), tokenId);

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -337,7 +337,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateCommission(uint256 auctionId) internal {
+    function _generateCommission(uint256 auctionId) internal returns (uint256) {
         return auctions[auctionId].amount.div(100).mul(auctions[auctionId].commissionPercentage);
     }
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -113,7 +113,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
     function setBeneficiaryAddress(address tokenContract, address payable newBeneficiary) external override {
         // TODO - access controls
-        royaltyRegistry[tokenContract].beneficiaryAddress = newBeneficiary;
+        royaltyRegistry[tokenContract].beneficiary = newBeneficiary;
         emit BeneficiaryAddressUpdated(tokenContract, commissionAddress);
     }
 
@@ -237,7 +237,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             return;
         }
 
-        if (auctions[auctionId].commissionAddress != address(0) && auctions[auctionId].commissionPercentage > 0){
+        if (royaltyRegistry[auctions[auctionId].tokenContract].benf != address(0) && auctions[auctionId].commissionPercentage > 0){
             uint256 commissionAmount = _generateCommission(auctionId);
             uint256 amountRemaining = tokenOwnerProfit.sub(commissionAmount);
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -237,23 +237,23 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             return;
         }
 
-        if (royaltyRegistry[auctions[auctionId].tokenContract].benf != address(0) && auctions[auctionId].commissionPercentage > 0){
-            uint256 commissionAmount = _generateCommission(auctionId);
-            uint256 amountRemaining = tokenOwnerProfit.sub(commissionAmount);
-
-            _handleOutgoingBid(auctions[auctionId].tokenOwner, amountRemaining, auctions[auctionId].auctionCurrency);
+        if (royaltyRegistry[auctions[auctionId].tokenContract].benficiary != address(0) && royaltyRegistry[auctions[auctionId].tokenContract].royaltyPercentage > 0){
+            uint256 royaltyAmount = _generateRoyaltyAmount(tokenContract);
+            uint256 amountRemaining = tokenOwnerProfit.sub(royaltyAmount);
 
             _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(auctions[auctionId].tokenOwner, amountRemaining, auctions[auctionId].auctionCurrency);
 
-            emit AuctionWithCommissionEnded(
+
+            emit AuctionWithRoyaltiesEnded(
                 auctionId,
                 auctions[auctionId].tokenId,
                 auctions[auctionId].tokenContract,
                 auctions[auctionId].tokenOwner,            
                 auctions[auctionId].bidder,
-                tokenOwnerProfit,
-                auctions[auctionId].commissionAddress,
-                commissionAmount,            
+                amountRemaining,
+                royaltyRegistry[auctions[auctionId].tokenContract].benficiary,
+                royaltyAmount,            
                 currency
             );
 
@@ -324,8 +324,8 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateCommission(uint256 auctionId) internal returns (uint256) {
-        return auctions[auctionId].amount.div(100).mul(auctions[auctionId].commissionPercentage);
+    function _generateRoyaltyAmount(address tokenContract) internal returns (uint256) {
+        return auctions[auctionId].amount.div(100).mul(royaltyRegistry[tokenContract].royaltyPercentage);
     }
 
     function _safeTransferETH(address to, uint256 value) internal returns (bool) {

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -229,6 +229,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         address currency = auctions[auctionId].auctionCurrency == address(0) ? wethAddress : auctions[auctionId].auctionCurrency;
 
         uint256 tokenOwnerProfit = auctions[auctionId].amount;
+        address tokenContract = auctions[auctionId].tokenContract;
  
         // Otherwise, transfer the token to the winner and pay out the participants below
         try IERC721(auctions[auctionId].tokenContract).safeTransferFrom(address(this), auctions[auctionId].bidder, auctions[auctionId].tokenId) {} catch {
@@ -237,10 +238,10 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             return;
         }
 
-        if (royaltyRegistry[auctions[auctionId].tokenContract].beneficiary != address(0) && royaltyRegistry[auctions[auctionId].tokenContract].royaltyPercentage > 0){
+        if (royaltyRegistry[tokenContract].beneficiary != address(0) && royaltyRegistry[tokenContract].royaltyPercentage > 0){
             uint256 royaltyAmount = _generateRoyaltyAmount(auctionId, auctions[auctionId].tokenContract);
             uint256 amountRemaining = tokenOwnerProfit.sub(royaltyAmount);
-            address tokenContract = auctions[auctionId].tokenContract;
+            
 
             _handleOutgoingBid(royaltyRegistry[tokenContract].beneficiary, royaltyAmount, auctions[auctionId].auctionCurrency);
             _handleOutgoingBid(auctions[auctionId].tokenOwner, amountRemaining, auctions[auctionId].auctionCurrency);

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -32,9 +32,6 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
     // The minimum percentage difference between the last bid amount and the current bid.
     uint8 public minBidIncrementPercentage;
 
-    // The address of the zora protocol to use via this contract
-    address public zora;
-
     // / The address of the WETH contract, so that any ETH transferred can be handled as an ERC-20
     address public wethAddress;
 
@@ -56,12 +53,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
     /*
      * Constructor
      */
-    constructor(address _zora, address _weth) public {
-        require(
-            IERC165(_zora).supportsInterface(interfaceId),
-            "Doesn't support NFT interface"
-        );
-        zora = _zora;
+    constructor(address _weth) public {
         wethAddress = _weth;
         timeBuffer = 15 * 60; // extend 15 minutes after every bid made in last 15 minutes
         minBidIncrementPercentage = 5; // 5%

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -111,19 +111,19 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionReservePriceUpdated(auctionId, auctions[auctionId].tokenId, auctions[auctionId].tokenContract, reservePrice);
     }
 
-    function setBeneficiaryAddress(address tokenContract, address payable newBeneficiary) external override {
+    /**
+     * @notice Set royalty information for a given token contract.
+     * @dev Store the royal details in the royaltyRegistry mapping and emit an royaltySet event.     
+     */
+    function setRoyalty(address tokenContract, address payable beneficiary, uint royaltyPercentage) external override {
         // TODO - access controls
-        royaltyRegistry[tokenContract].beneficiary = newBeneficiary;
-        emit BeneficiaryAddressUpdated(tokenContract, commissionAddress);
+        royaltyRegistry[tokenContract] = Royalty({
+            beneficiary: beneficiary,
+            royaltyPercentage: royaltyPercentage
+        });
+        emit RoyaltySet(tokenContract, beneficiary, royaltyPercentage);
     }
 
-    function setRoyaltyPercentage(address tokenContract, uint256 newRoyaltyPercentage) external override {
-        // TODO - access controls
-
-        royaltyRegistry[tokenContract].royaltyPercentage = newRoyaltyPercentage;
-
-        emit RoyaltyPercentageUpdated(tokenContract, newRoyaltyPercentage);
-    }
 
     /**
      * @notice Create a bid on a token, with a given amount.

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -97,7 +97,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         _auctionIdTracker.increment();
 
-        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency, commissionAddress, commissionPercentage);
+        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency);
  
         return auctionId;
     }
@@ -237,11 +237,12 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             return;
         }
 
-        if (royaltyRegistry[auctions[auctionId].tokenContract].benficiary != address(0) && royaltyRegistry[auctions[auctionId].tokenContract].royaltyPercentage > 0){
-            uint256 royaltyAmount = _generateRoyaltyAmount(tokenContract);
+        if (royaltyRegistry[auctions[auctionId].tokenContract].beneficiary != address(0) && royaltyRegistry[auctions[auctionId].tokenContract].royaltyPercentage > 0){
+            uint256 royaltyAmount = _generateRoyaltyAmount(auctionId, auctions[auctionId].tokenContract);
             uint256 amountRemaining = tokenOwnerProfit.sub(royaltyAmount);
+            address tokenContract = auctions[auctionId].tokenContract;
 
-            _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(royaltyRegistry[tokenContract].beneficiary, royaltyAmount, auctions[auctionId].auctionCurrency);
             _handleOutgoingBid(auctions[auctionId].tokenOwner, amountRemaining, auctions[auctionId].auctionCurrency);
 
 
@@ -252,7 +253,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
                 auctions[auctionId].tokenOwner,            
                 auctions[auctionId].bidder,
                 amountRemaining,
-                royaltyRegistry[auctions[auctionId].tokenContract].benficiary,
+                royaltyRegistry[tokenContract].beneficiary,
                 royaltyAmount,            
                 currency
             );
@@ -324,7 +325,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateRoyaltyAmount(address tokenContract) internal returns (uint256) {
+    function _generateRoyaltyAmount(uint256 auctionId, address tokenContract) internal returns (uint256) {
         return auctions[auctionId].amount.div(100).mul(royaltyRegistry[tokenContract].royaltyPercentage);
     }
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -325,7 +325,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateRoyaltyAmount(uint256 auctionId, address tokenContract) internal returns (uint256) {
+    function _generateRoyaltyAmount(uint256 auctionId, address tokenContract) internal view returns (uint256) {
         return auctions[auctionId].amount.div(100).mul(royaltyRegistry[tokenContract].royaltyPercentage);
     }
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -19,7 +19,7 @@ interface IWETH {
 }
 
 /**
- * @title The ChainSaw AuctionHouse
+ * @title The Chain/Saw AuctionHouse
  */
 contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
     using SafeMath for uint256;

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -39,7 +39,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
     mapping(uint256 => IAuctionHouse.Auction) public auctions;
 
     //A mapping of token contracts to royalty objects
-    mapping(address => IAuctionHouse.Royalty) public royaltyRegistry
+    mapping(address => IAuctionHouse.Royalty) public royaltyRegistry;
 
     bytes4 constant interfaceId = 0x80ac58cd; // 721 interface id
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -98,7 +98,7 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
-    event AuctionEndedWithCommission(
+    event AuctionWithCommissionEnded(
         uint256 indexed auctionId,
         uint256 indexed tokenId,
         address indexed tokenContract,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -130,9 +130,9 @@ interface IAuctionHouse {
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 
-    function updateCommissionAddress(address commissionAddress) external;
+    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external;
 
-    function updateCommissionPercentage(address commissionAddress) external;
+    function updateCommissionPercentage(uint256 auctionId, address commissionAddress) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -98,6 +98,18 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
+    event AuctionEndedWithCommission(
+        uint256 indexed auctionId,
+        uint256 indexed tokenId,
+        address indexed tokenContract,
+        address tokenOwner,        
+        address winner,
+        uint256 amount,
+        address commissionAddress,
+        uint256 commissionAmount,        
+        address auctionCurrency
+    );
+
     event AuctionCanceled(
         uint256 indexed auctionId,
         uint256 indexed tokenId,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -62,12 +62,12 @@ interface IAuctionHouse {
     );
 
     event AuctionCommissionAddressUpdated(
-        uint256 indexed auctionId
+        uint256 indexed auctionId,
         address indexed commissionAddress
     )
 
     event AuctionCommissionAddressUpdated(
-        uint256 indexed auctionId
+        uint256 indexed auctionId,
         address indexed commissionAddress
     )
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -27,6 +27,13 @@ interface IAuctionHouse {
         // The address of the ERC-20 currency to run the auction with.
         // If set to 0x0, the auction will be run in ETH
         address auctionCurrency;
+        // The address of recipient of the sale commission
+        address commissionAddress;
+        //The address of the recipient of the sale commission
+        //If set to 0x0, no commission will generated
+        uint256 commissionPercentage;
+        // The percentage of the sale the commission address receives
+        //If percentage is set to 0, no commission will be generated
     }
 
     event AuctionCreated(
@@ -36,7 +43,9 @@ interface IAuctionHouse {
         uint256 duration,
         uint256 reservePrice,
         address tokenOwner,        
-        address auctionCurrency
+        address auctionCurrency,
+        address commissionAddress,
+        uint8 commissionPercentage
     );
 
     event AuctionApprovalUpdated(
@@ -51,6 +60,16 @@ interface IAuctionHouse {
         address indexed tokenContract,
         uint256 reservePrice
     );
+
+    event AuctionCommissionAddressUpdated(
+        uint256 indexed auctionId
+        address indexed commissionAddress
+    )
+
+    event AuctionCommissionAddressUpdated(
+        uint256 indexed auctionId
+        address indexed commissionAddress
+    )
 
     event AuctionBid(
         uint256 indexed auctionId,
@@ -91,11 +110,17 @@ interface IAuctionHouse {
         address tokenContract,
         uint256 duration,
         uint256 reservePrice,        
-        address auctionCurrency
+        address auctionCurrency,
+        address commissionAddress,
+        uint8 comissionPercentage
     ) external returns (uint256);
 
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
+
+    function updateCommissionAddress(address commissionAddress) external;
+
+    function updateCommissionPercentage(address commissionAddress) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -64,12 +64,12 @@ interface IAuctionHouse {
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
         address indexed commissionAddress
-    )
+    );
 
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
         address indexed commissionAddress
-    )
+    );
 
     event AuctionBid(
         uint256 indexed auctionId,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -132,7 +132,7 @@ interface IAuctionHouse {
 
     function updateCommissionAddress(uint256 auctionId, address commissionAddress) external;
 
-    function updateCommissionPercentage(uint256 auctionId, address commissionAddress) external;
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -63,12 +63,12 @@ interface IAuctionHouse {
 
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
-        address indexed commissionAddress
+        address indexed newCommissionAddress
     );
 
-    event AuctionCommissionAddressUpdated(
+    event AuctionCommissionPercentageUpdated(
         uint256 indexed auctionId,
-        address indexed commissionAddress
+        uint256 indexed newCommissionPercentage
     );
 
     event AuctionBid(

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -32,7 +32,7 @@ interface IAuctionHouse {
 
     struct Royalty {
         //The address of the beneficiary who will be receiving royalties for each sale
-        address payable beneficiaryAddress;
+        address payable beneficiary;
         //The percentage of the sale the commission address receives
         //If percentage is set to 0, the full amount will be sent
         uint256 royaltyPercentage;

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -46,9 +46,7 @@ interface IAuctionHouse {
         uint256 duration,
         uint256 reservePrice,
         address tokenOwner,        
-        address auctionCurrency,
-        address commissionAddress,
-        uint8 commissionPercentage
+        address auctionCurrency
     );
 
     event AuctionApprovalUpdated(

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -101,7 +101,7 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
-    event AuctionWithEnded(
+    event AuctionWithRoyaltiesEnded(
         uint256 indexed auctionId,
         uint256 indexed tokenId,
         address indexed tokenContract,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -64,12 +64,12 @@ interface IAuctionHouse {
         uint256 reservePrice
     );
 
-    event AuctionBeneficiaryAddressUpdated(
+    event BeneficiaryAddressUpdated(
         address indexed tokenContract,
-        address indexed newBeneficiaryAddress
+        address indexed newBeneficiary
     );
 
-    event AuctionRoyaltyPercentageUpdated(
+    event RoyaltyPercentageUpdated(
         address indexed tokenContract,
         uint256 indexed newRoyaltyPercentage
     );
@@ -131,7 +131,7 @@ interface IAuctionHouse {
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 
-    function setBeneficiaryAddress(address tokenContract, address beneficiaryAddress) external;
+    function setBeneficiaryAddress(address tokenContract, address payable beneficiaryAddress) external;
 
     function setRoyaltyPercentage(address tokenContract, uint256 royaltyPercentage) external;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -125,9 +125,7 @@ interface IAuctionHouse {
         address tokenContract,
         uint256 duration,
         uint256 reservePrice,        
-        address auctionCurrency,
-        address commissionAddress,
-        uint8 comissionPercentage
+        address auctionCurrency
     ) external returns (uint256);
 
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -28,12 +28,15 @@ interface IAuctionHouse {
         // If set to 0x0, the auction will be run in ETH
         address auctionCurrency;
         // The address of recipient of the sale commission
-        address commissionAddress;
-        //The address of the recipient of the sale commission
-        //If set to 0x0, no commission will generated
-        uint256 commissionPercentage;
-        // The percentage of the sale the commission address receives
-        //If percentage is set to 0, no commission will be generated
+    }
+
+    struct Royalty {
+        //The address of the beneficiary who will be receiving royalties for each sale
+        address payable beneficiaryAddress;
+        //The percentage of the sale the commission address receives
+        //If percentage is set to 0, the full amount will be sent
+        uint256 royaltyPercentage;
+
     }
 
     event AuctionCreated(
@@ -61,14 +64,14 @@ interface IAuctionHouse {
         uint256 reservePrice
     );
 
-    event AuctionCommissionAddressUpdated(
-        uint256 indexed auctionId,
-        address indexed newCommissionAddress
+    event AuctionBeneficiaryAddressUpdated(
+        address indexed tokenContract,
+        address indexed newBeneficiaryAddress
     );
 
-    event AuctionCommissionPercentageUpdated(
-        uint256 indexed auctionId,
-        uint256 indexed newCommissionPercentage
+    event AuctionRoyaltyPercentageUpdated(
+        address indexed tokenContract,
+        uint256 indexed newRoyaltyPercentage
     );
 
     event AuctionBid(
@@ -98,15 +101,15 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
-    event AuctionWithCommissionEnded(
+    event AuctionWithEnded(
         uint256 indexed auctionId,
         uint256 indexed tokenId,
         address indexed tokenContract,
         address tokenOwner,        
         address winner,
         uint256 amount,
-        address commissionAddress,
-        uint256 commissionAmount,        
+        address beneficiaryAddress,
+        uint256 royaltyAmount,        
         address auctionCurrency
     );
 
@@ -130,9 +133,9 @@ interface IAuctionHouse {
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 
-    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external;
+    function updateBeneficiaryAddress(address tokenContract, address beneficiaryAddress) external;
 
-    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external;
+    function updateRoyaltyPercentage(address tokenContract, uint256 royaltyPercentage) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -131,9 +131,9 @@ interface IAuctionHouse {
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 
-    function updateBeneficiaryAddress(address tokenContract, address beneficiaryAddress) external;
+    function setBeneficiaryAddress(address tokenContract, address beneficiaryAddress) external;
 
-    function updateRoyaltyPercentage(address tokenContract, uint256 royaltyPercentage) external;
+    function setRoyaltyPercentage(address tokenContract, uint256 royaltyPercentage) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -64,14 +64,10 @@ interface IAuctionHouse {
         uint256 reservePrice
     );
 
-    event BeneficiaryAddressUpdated(
+    event RoyaltySet(
         address indexed tokenContract,
-        address indexed newBeneficiary
-    );
-
-    event RoyaltyPercentageUpdated(
-        address indexed tokenContract,
-        uint256 indexed newRoyaltyPercentage
+        address indexed newBeneficiary,
+        uint256 indexed royaltyPercentage
     );
 
     event AuctionBid(
@@ -131,9 +127,8 @@ interface IAuctionHouse {
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 
-    function setBeneficiaryAddress(address tokenContract, address payable beneficiaryAddress) external;
+    function setRoyalty(address tokenContract, address payable beneficiaryAddress, uint256 royaltyPercentage) external;
 
-    function setRoyaltyPercentage(address tokenContract, uint256 royaltyPercentage) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 


### PR DESCRIPTION
Royalty functionality is now mapped to token contract addresses.  The endAuction function now queries the mapping for a Royalty object for a given token contract address. If it exists, the royalty amount is deducted from the winning bid and sent to the beneficiary. The remaining amount is sent to the token owner. If a Royalty object does not exist in the mapping, the entire amount will be sent to the token owner. Royalty information can now be set in a single setter function.